### PR TITLE
Allow GitHub Pages names to have numbers in them

### DIFF
--- a/src/main/java/net/trajano/wagon/git/GitHubPagesWagon.java
+++ b/src/main/java/net/trajano/wagon/git/GitHubPagesWagon.java
@@ -34,7 +34,7 @@ public class GitHubPagesWagon extends AbstractGitWagon {
      * Github pages host pattern.
      */
     private static final Pattern GITHUB_PAGES_HOST_PATTERN = Pattern
-            .compile("([a-z-]+)\\.github\\.io.?");
+            .compile("([a-z0-9-]+)\\.github\\.io.?");
 
     /**
      * Github pages path pattern.


### PR DESCRIPTION
Quick correction to the pages host matching regex to take into account GitHub usernames with numbers in them (such as mine). Tested with my projects as the integration tests do not function without @trajano 's SSH keys.