### PR TITLE
Swap to use passphrase (and latest version of git library)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,12 @@ Protected private keys
 ----------------------
 If you are using a passphrase to protect your private key, then in 
 `settings.xml`, then should be a `<server>` definition with the `<id>` 
-corresponding to the `<distributionManagement><site><id>` without the 
-`<user>` for example:
+corresponding to the `<distributionManagement><site><id>` and with a 
+`<passphrase>` element but without the `<user>`.  For example:
 
     <server>
         <id>gh-pages</id>
-        <password>privatekeypassword</password>
+        <passphrase>privatekeypassphrase</passphrase>
     </server>
 
 If you're not protecting your private key, then no additional changes are 

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
-            <version>4.0.0.201506090130-r</version>
+            <version>4.0.1.201506240215-r</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/net/trajano/wagon/git/internal/AbstractGitWagon.java
+++ b/src/main/java/net/trajano/wagon/git/internal/AbstractGitWagon.java
@@ -263,11 +263,11 @@ public abstract class AbstractGitWagon extends StreamWagon {
         gitDir.delete();
         gitDir.mkdir();
 
-        if (getAuthenticationInfo().getUserName() != null) {
+        if (getAuthenticationInfo().getPassphrase() != null) {
+            credentialsProvider = new PassphraseCredentialsProvider(getAuthenticationInfo().getPassphrase());
+        } else {
             credentialsProvider = new UsernamePasswordCredentialsProvider(getAuthenticationInfo().getUserName(), getAuthenticationInfo().getPassword() == null ? "" //$NON-NLS-1$
                     : getAuthenticationInfo().getPassword());
-        } else {
-            credentialsProvider = new PassphraseCredentialsProvider(getAuthenticationInfo().getPassword());
         }
         try {
             final Git git = Git.cloneRepository()


### PR DESCRIPTION
This should improve docs and utility with trajano/wagon-git#9 as well as updating the version of `org.eclipse.jgit: org.eclipse.jgit` to `4.0.1.201506240215-r`

Note that having a trailing site path does work and seems to work correctly.  It won't remove existing files, and since there are multiple commits on a multi-module repo it seems the be the case that gh-pages doesn't update.  It's possible that adding a pause between module commits might do the trick?