### PR TITLE
The other half of "added support for ssh-agent".

### DIFF
--- a/src/main/java/net/trajano/wagon/git/internal/AbstractGitWagon.java
+++ b/src/main/java/net/trajano/wagon/git/internal/AbstractGitWagon.java
@@ -109,6 +109,7 @@ public abstract class AbstractGitWagon extends StreamWagon {
                 git.push()
                         .setRemote(gitEntry.getKey())
                         .setCredentialsProvider(credentialsProvider)
+                        .setTransportConfigCallback(new JSchAgentCapableTransportConfigCallback())
                         .call();
                 git.close();
                 FileUtils.deleteDirectory(git.getRepository()


### PR DESCRIPTION
The JSchAgentCapableTransportConfigCallback needs to be registered
on the push command as well as on the clone command.

Resolves #13 (for me anyway).